### PR TITLE
Dynamicregistrationform

### DIFF
--- a/assets/css/newstemplate.css
+++ b/assets/css/newstemplate.css
@@ -11,6 +11,10 @@
   flex: 30%;
 }
 
+.news-column-noimg:first-child {
+  flex: 100%;
+}
+
 .news-column:last-child {
   flex: 70%;
 }
@@ -19,4 +23,58 @@
   .news-column {
     flex: 100% !important;
   }
+}
+
+/* General form styling */
+form {
+  width: 100%;
+  margin: 0  auto;
+  padding: 20px;
+  background-color: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+/* Label styling */
+form label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: bold;
+  color: #333;
+}
+
+/* Input field styling */
+form input{
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 20px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+/* Submit button styling */
+form input[type="submit"] {
+  width: 100%;
+  padding: 10px;
+  background-color: #4CAF50;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+form input[type="submit"]:hover {
+  background-color: #45a049;
+}
+
+.form-row {
+    display: flex;
+    gap: 10px;
+}
+
+.form-group {
+    flex: 1;
 }

--- a/includes/news-template.php
+++ b/includes/news-template.php
@@ -23,7 +23,8 @@
                 $sql = "SELECT `registration_needed`, `registration_fields`, `registration_enddate` FROM `events` WHERE id = ".$row["eventid"]."";
                 $result = $conn->query($sql);
                 $row = $result->fetch_assoc();
-                if ($row['registration_needed'] != '0') {
+                echo $row['registration_enddate'];
+                if ($row['registration_needed'] != '0' && strtotime($row['registration_enddate']) > time()) {
                     echo "</div>";
                     echo "<div class='news-row'>";
                         echo "<div class='news-column-noimg'>";

--- a/includes/news-template.php
+++ b/includes/news-template.php
@@ -3,20 +3,86 @@
 
 <div class="block-overview">
     <div class="heading-title">
-        <h2 class="block-title"> <?= htmlspecialchars($row["title"]) ?> </h2>
+        <h2 class="block-title"> <?= $row["title"] ?> </h2>
     </div>
     <div class="block-text">
         <div class="news-row">
         <?php
+            $eventid = $row['eventid'];
             if ($row['image_url'] != '') {
                 echo "<div class='news-column'>";
-                    echo "<img src='".htmlspecialchars($row["image_url"])."' alt='".htmlspecialchars($row["title"])."'>";
+                    echo "<img src='".$row["image_url"]."' alt='".$row["title"]."'>";
                 echo "</div>";
                 echo "<div class='news-column'>";
-                    echo htmlspecialchars($row["text"]);
+                    echo $row["text"];
                 echo "</div>";
             } else {
-                echo htmlspecialchars($row["text"]);
+                echo "<div class='news-column-noimg'>".$row["text"]."</div>";
+            }
+            if ($row['eventid'] != '') {
+                $sql = "SELECT `registration_needed`, `registration_fields`, `registration_enddate` FROM `events` WHERE id = ".$row["eventid"]."";
+                $result = $conn->query($sql);
+                $row = $result->fetch_assoc();
+                if ($row['registration_needed'] != '0') {
+                    echo "</div>";
+                    echo "<div class='news-row'>";
+                        echo "<div class='news-column-noimg'>";
+                            echo "<form id='registrationForm' method='POST' action='submit_registration.php'>";
+                                $fields = explode(", ", $row['registration_fields']);
+                                $translations = [
+                                    'firstname' => 'Voornaam',
+                                    'lastname' => 'Achternaam',
+                                    'phone' => 'Telefoonnummer',
+                                    'email' => 'E-mail',
+                                    'street' => 'Straatnaam',
+                                    'postalcode' => 'Postcode',
+                                    'housenumber' => 'Huisnummer',
+                                    'addition' => 'Toevoeging',
+                                    'amount_people' => 'Aantal personen',
+                                    'groupname' => 'Groepsnaam',
+                                    // Add more translations as needed
+                                ];
+                                
+                                foreach ($fields as $field) {
+                                    $dutchField = isset($translations[$field]) ? $translations[$field] : $field;
+                                    if ($field == 'postalcode' || $field == 'housenumber' || $field == 'addition') {
+                                        if ($field == 'postalcode') {
+                                            echo "<div class='form-row'>";
+                                        }
+                                        echo "<div class='form-group'>";
+                                        echo "<label for='".$field."'>".$dutchField.": </label>";
+                                        if ($field == 'postalcode') {
+                                            echo "<input type='text' id='".$field."' name='".$field."' placeholder='".($field == 'postalcode' ? '1234AB' : '')."' pattern='".($field == 'postalcode' ? '^[1-9][0-9]{3}[A-Z]{2}$' : '')."' title='".($field == 'postalcode' ? 'Voer een geldige Nederlandse postcode in (bijv. 1234AB)' : '')."' required>";
+                                        }
+                                        if ($field == 'housenumber') {
+                                            echo "<input type='number' id='".$field."' name='".$field."' required>";
+                                        }
+                                        if ($field == 'addition') {
+                                            echo "<input type='text' id='".$field."' name='".$field."'>";
+                                        }
+                                        echo "</div>";
+                                        if ($field == 'addition') {
+                                            echo "</div>";
+                                        }
+                                    } else {
+                                        echo "<label for='".$field."'>".$dutchField.": </label>";
+                                        if ($field == 'phone') {
+                                            echo "<input type='tel' id='".$field."' name='".$field."' placeholder='06-12345678' pattern='^06[0-9]{8}$' title='Voer een geldig Nederlands mobiel nummer in (bijv. 0612345678)' required><br>";
+                                        } elseif ($field == 'email') {
+                                            echo "<input type='email' id='".$field."' name='".$field."' required><br>";
+                                        } elseif ($field == 'amount_people') {
+                                            echo "<input type='number' id='".$field."' name='".$field."' value='1' required><br>";
+                                        } else {
+                                            echo "<input type='text' id='".$field."' name='".$field."' required><br>";
+                                        }
+                                    }
+                                }
+                                echo "<input type='hidden' id='eventid' name='eventid' value='".$eventid."'>";
+                                echo "<input type='submit' value='Aanmelden'>";
+                            echo "</form>";
+                        echo "</div>";
+                    echo "</div>";
+                }
             }
         ?>
         </div>

--- a/includes/news-template.php
+++ b/includes/news-template.php
@@ -23,7 +23,6 @@
                 $sql = "SELECT `registration_needed`, `registration_fields`, `registration_enddate` FROM `events` WHERE id = ".$row["eventid"]."";
                 $result = $conn->query($sql);
                 $row = $result->fetch_assoc();
-                echo $row['registration_enddate'];
                 if ($row['registration_needed'] != '0' && strtotime($row['registration_enddate']) > time()) {
                     echo "</div>";
                     echo "<div class='news-row'>";

--- a/submit_registration.php
+++ b/submit_registration.php
@@ -1,0 +1,35 @@
+<?php
+include './templates/dbconnection.php';
+
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    $fields = ['firstname', 'lastname', 'phone', 'email', 'street', 'postalcode', 'housenumber', 'addition', 'amount_people', 'groupname', 'eventid'];
+    $data = [];
+    $columns = [];
+    $values = [];
+    
+    foreach ($fields as $field) {
+        if (isset($_POST[$field])) {
+            $data[$field] = $conn->real_escape_string($_POST[$field]);
+            $columns[] = $field;
+            $values[] = "'" . $data[$field] . "'";
+        }
+    }
+
+    if (!empty($columns)) {
+        $sql = "INSERT INTO registrations (" . implode(", ", $columns) . ") VALUES (" . implode(", ", $values) . ")";
+        echo $sql;
+
+
+        if ($conn->query($sql) === TRUE) {
+            echo "Registration successful!";
+        } else {
+            echo $values."<br>";
+            echo "Error: " . $sql . "<br>" . $conn->error;
+        }
+    } else {
+        echo "No data to insert.";
+    }
+
+    $conn->close();
+}
+?>


### PR DESCRIPTION
DB STUCTURE CHANGE! This PR changed the news & events tables and introduces a new registrations table so updating your local DB is necessary when pulling this PR.

A news item can now have a registrationform.
The way this works is: an event now got a few additional fields and one of them is a boolean which indicates if you can register. Another field contains which data the registration form needs. There is another field in which you can specify the ultimatum for the registration to be in (not used yet).

A news item can be linked to an event so that if you press the news item and the event accepts registrations the user will be presented with the registration form.